### PR TITLE
Rename to `@sigmacomputing/babel-plugin-lodash` and fix module declaration bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,13 @@
 {
-  "name": "babel-plugin-lodash",
+  "name": "@sigmacomputing/babel-plugin-lodash",
   "version": "3.3.4",
   "description": "Modular Lodash builds without the hassle.",
-  "keywords": "babel-plugin, cherry-pick, lodash, modules",
+  "keywords": [
+    "babel-plugin",
+    "cherry-pick",
+    "lodash",
+    "modules"
+  ],
   "repository": "lodash/babel-plugin-lodash",
   "license": "MIT",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sigmacomputing/babel-plugin-lodash",
-  "version": "3.3.4",
+  "version": "3.3.5",
   "description": "Modular Lodash builds without the hassle.",
   "keywords": [
     "babel-plugin",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import _ from 'lodash'
-import { isModuleDeclaration } from '@babel/types'
+import { isImportDeclaration, isExportDeclaration } from '@babel/types'
 
 import config from './config'
 import importModule from './importModule'
@@ -72,7 +72,7 @@ export default function lodash({ types }) {
       let isModule = false
 
       for (const node of file.ast.program.body) {
-        if (isModuleDeclaration(node)) {
+        if (isImportDeclaration(node) || isExportDeclaration(node)) {
           isModule = true
           break
         }


### PR DESCRIPTION
Fork original lodash/babel-plugin-lodash to `@sigmacomputing/babel-plugin-lodash`
* [#261](https://github.com/lodash/babel-plugin-lodash/pull/261) hasn't seen any kind of acknowledgement from the package authors

> Resolves [#259](https://github.com/lodash/babel-plugin-lodash/issues/259)
>
> The `isModuleDeclaration` method was [recently deprecated](https://github.com/babel/babel/pull/15266) in 
https://github.com/babel/babel/pull/15266 which causes deprecation notices akin to the following:
> ```
> Trace: `isModuleDeclaration` has been deprecated, please migrate to `isImportOrExportDeclaration`.
>     at isModuleDeclaration (/path/to/example/node_modules/@babel/types/lib/validators/generated/index.js:3939:11)
>     at PluginPass.Program (/path/to/example/node_modules/babel-plugin-example/lib/index.js:102:44)
>     at newFn (/path/to/example/node_modules/@babel/traverse/lib/visitors.js:148:21)
>     at NodePath._call (/path/to/example/node_modules/@babel/traverse/lib/path/context.js:45:20)
>     at NodePath.call (/path/to/example/node_modules/@babel/traverse/lib/path/context.js:35:17)
>     at NodePath.visit (/path/to/example/node_modules/@babel/traverse/lib/path/context.js:80:31)
>     at TraversalContext.visitQueue (/path/to/example/node_modules/@babel/traverse/lib/context.js:86:16)
>     at TraversalContext.visitSingle (/path/to/example/node_modules/@babel/traverse/lib/context.js:65:19)
>     at TraversalContext.visit (/path/to/example/node_modules/@babel/traverse/lib/context.js:109:19)
>     at traverseNode (/path/to/example/node_modules/@babel/traverse/lib/traverse-node.js:18:17)
> ```
> 
> According to the migration guide, babel plugins are recommended to replace the method with either `isImportOrExportDeclaration` in the case where backward compatibility is not essential. Or, if backward compatibility is an issue, a combination of `isImportDeclaration` and `isExportDeclaration`. This PR applies the latter. 
> 
> The recommendation mentioned above can be found in the "Migration guide (for plugin authors)" section of https://github.com/babel/babel/pull/15266. 
> 
> Relates to [#260](https://github.com/lodash/babel-plugin-lodash/issues/260) – I didn't have permission to update that PR and it hasn't had any movement from the PR author for a while.